### PR TITLE
Add generation of schemas/rust code and validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,13 @@ anyhow = "1.0.70"
 base64 = "0.21"
 chrono = { version = "0.4.24", features = ["serde"] }
 clap = { version = "4.2.4", features = ["derive"] }
+jsonschema = "0.17.0"
+prettyplease = "0.2.4"
+schemars = { version = "0.8.12", features = ["chrono", "url"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+syn = "2.0.15"
+typify = "0.0.12"
 url = "2.2"
 
 [dev-dependencies]

--- a/src/bin/bin.rs
+++ b/src/bin/bin.rs
@@ -2,14 +2,22 @@
 //!
 //! This tool currently supports validating In-Toto v1 documents with
 //! SLSA Provenance v1 predicates.
+//! TODO(mlieberman85): The CLI commands and args could probably be generalized better to minimize duplication.
 
-use std::process;
+use std::{path::PathBuf, process};
 
-use anyhow::{anyhow, Result};
-use clap::Parser;
-use spector::models::intoto::{predicate::Predicate, statement::InTotoStatementV1};
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use spector::{
+    models::intoto::{
+        predicate::Predicate, provenance::SLSAProvenanceV1Predicate, statement::InTotoStatementV1,
+    },
+    validate::{self, Validator},
+};
+use typify::{TypeSpace, TypeSpaceSettings};
 
-/// The top-level CLI parser.
 #[derive(Parser)]
 #[clap(
     version = "0.0.1",
@@ -20,85 +28,171 @@ struct Spector {
     command: Command,
 }
 
-/// The available subcommands.
+// The available subcommands
 #[derive(Parser)]
 enum Command {
     Validate(Validate),
+    SchemaGenerate(SchemaGenerate),
+    CodeGenerate(CodeGenerate),
+    SchemaValidate(SchemaValidate),
 }
 
-/// The `validate` subcommand.
-/// Currently only supports validating documents.
+// The `code-generate` subcommand
+#[derive(Parser)]
+struct CodeGenerate {
+    #[clap(subcommand)]
+    codegen: CodeGenerateSubCommand,
+}
+
+// The supported code generation types
+#[derive(Parser)]
+enum CodeGenerateSubCommand {
+    JsonSchema(JsonSchema),
+}
+
+#[derive(Parser)]
+struct JsonSchema {
+    /// Path to the file to generate a schema for
+    /// TODO(mlieberman85): Make this optional once we support stdin
+    /// TODO(mlieberman85): Figure out how to generalize this to all applicable subcommands
+    #[clap(value_parser)]
+    #[clap(long, short, required = true)]
+    file: PathBuf,
+}
+
+// The `validate` subcommand
 #[derive(Parser)]
 struct Validate {
     #[clap(subcommand)]
-    document: DocumentSubCommand,
+    document: ValidateDocumentSubCommand,
 }
 
-/// The supported document types.
-/// Currently only supports In-Toto v1 attestation statement documents.
+// The `generate` subcommand
 #[derive(Parser)]
-enum DocumentSubCommand {
-    InTotoV1(InTotoV1),
-}
-
-/// The In-Toto v1 document subcommand.
-#[derive(Parser)]
-struct InTotoV1 {
+struct SchemaGenerate {
     #[clap(subcommand)]
-    predicate_subcommand: PredicateSubcommand,
+    document: GenerateDocumentSubCommand,
 }
 
-/// The supported predicate types for In-Toto v1 documents.
-/// Currently supports only SLSA Provenance v1 predicates.
+// The `schema-validate` subcommand
 #[derive(Parser)]
-enum PredicateSubcommand {
-    SLSAProvenanceV1(SLSAProvenanceV1),
+struct SchemaValidate {
+    /// Path to the schema file
+    #[clap(value_parser)]
+    schema: PathBuf,
+
+    /// Path to the file to validate
+    // TODO(mlieberman85): Make this optional once we support stdin
+    #[clap(value_parser)]
+    #[clap(long, short, required = true)]
+    file: PathBuf,
 }
 
-/// The SLSA Provenance v1 predicate subcommand.
-/// Currently only supports validating files.
+// The supported validate document types
 #[derive(Parser)]
-struct SLSAProvenanceV1 {
-    #[clap(short, long, required = true)]
-    file: String,
+enum ValidateDocumentSubCommand {
+    InTotoV1(ValidateInTotoV1),
 }
+
+// The supported schema generate document types
+#[derive(Parser)]
+enum GenerateDocumentSubCommand {
+    InTotoV1(GenerateInTotoV1),
+}
+
+// The In-Toto v1 validate document subcommand
+// TODO(mlieberman85): Add support for stdin
+// TODO(mlieberman85): Figure out a way to ensure file is added onto all document subcommands
+#[derive(Parser)]
+struct ValidateInTotoV1 {
+    /// Predicate type for In-Toto v1 documents
+    #[arg(value_enum)]
+    #[clap(long, short)]
+    predicate: Option<PredicateOption>,
+
+    /// Path to the file to validate
+    #[clap(value_parser)]
+    #[clap(long, short, required = true)]
+    file: PathBuf,
+}
+
+// The In-Toto v1 generate schema subcommand
+#[derive(Parser)]
+struct GenerateInTotoV1 {
+    /// Predicate type for In-Toto v1 documents
+    #[arg(value_enum)]
+    #[clap(long, short)]
+    predicate: Option<PredicateOption>,
+}
+
+#[derive(Copy, Clone, ValueEnum)]
+enum PredicateOption {
+    SLSAProvenanceV1,
+}
+
+#[derive(Parser)]
+struct SLSAProvenanceV1 {}
 
 /// Validates the specified document.
 fn validate_cmd(validate: Validate) -> Result<()> {
+    //let file_str = std::fs::read_to_string(&validate.file)?;
     match validate.document {
-        DocumentSubCommand::InTotoV1(in_toto) => handle_intoto_v1(in_toto),
+        ValidateDocumentSubCommand::InTotoV1(in_toto) => validate_intoto_v1(in_toto),
     }
 }
 
-/// Handles In-Toto v1 documents.
-fn handle_intoto_v1(in_toto: InTotoV1) -> Result<()> {
-    match in_toto.predicate_subcommand {
-        PredicateSubcommand::SLSAProvenanceV1(sl) => handle_slsa_provenance_v1(sl),
+/// Generates a schema for the specified type.
+fn generate_cmd(generate: SchemaGenerate) -> Result<()> {
+    match generate.document {
+        GenerateDocumentSubCommand::InTotoV1(in_toto) => generate_intoto_v1(in_toto),
     }
 }
 
-/// Handles SLSA Provenance v1 predicates in In-Toto v1 documents.
-///
-/// Prints the document if valid, otherwise prints an error message
-/// with the unexpected predicate type or JSON parsing error.
-fn handle_slsa_provenance_v1(sl: SLSAProvenanceV1) -> Result<()> {
-    let json_str = std::fs::read_to_string(sl.file)?;
-    let result = serde_json::from_str::<InTotoStatementV1>(&json_str);
+/// Handles validation for In-Toto v1 documents.
+fn validate_intoto_v1(in_toto: ValidateInTotoV1) -> Result<()> {
+    let file_str = std::fs::read_to_string(&in_toto.file)?;
+    let result = serde_json::from_str::<InTotoStatementV1>(&file_str);
 
     match result {
         Ok(statement) => {
             let pretty_json = serde_json::to_string_pretty(&statement)?;
-
             match statement.predicate {
-                Predicate::SLSAProvenanceV1(_) => {
-                    println!("Valid InTotoV1 SLSAProvenanceV1 document");
-                    println!("Document: {}", &pretty_json);
-                    Ok(())
-                }
+                Predicate::SLSAProvenanceV1(_) => match in_toto.predicate {
+                    Some(PredicateOption::SLSAProvenanceV1) => {
+                        println!("Valid InTotoV1 SLSAProvenanceV1 document");
+                        println!("Document: {}", &pretty_json);
+                        Ok(())
+                    }
+                    // TODO(mlieberman85): Uncomment below once additional predicate types are supported.
+                    /*Some(_) => {
+                        eprintln!("Invalid InTotoV1 SLSAProvenanceV1 document");
+                        eprintln!("Document: {}", &pretty_json);
+                        Err(anyhow::anyhow!(
+                            "Invalid InTotoV1 SLSAProvenanceV1 document"
+                        ))
+                    }*/
+                    None => {
+                        println!("Valid InTotoV1 SLSAProvenanceV1 document");
+                        println!("Document: {}", &pretty_json);
+                        Ok(())
+                    }
+                },
                 _ => {
-                    eprintln!("Unexpected predicateType: {:?}", statement.predicate_type.as_str());
-                    eprintln!("Document: {}", &pretty_json);
-                    Err(anyhow!("Unexpected predicateType: {:?}", statement.predicate_type.as_str()).into())
+                    if let Some(PredicateOption::SLSAProvenanceV1) = in_toto.predicate {
+                        eprintln!("Invalid InTotoV1 SLSAProvenanceV1 document");
+                        eprintln!("Document: {}", &pretty_json);
+                        Err(anyhow::anyhow!(
+                            "Unexpected predicateType: {:?}",
+                            statement.predicate_type.as_str()
+                        ))
+                    } else {
+                        println!(
+                            "Unknown predicateType: {:?}",
+                            statement.predicate_type.as_str()
+                        );
+                        println!("Document: {}", &pretty_json);
+                        Ok(())
+                    }
                 }
             }
         }
@@ -111,11 +205,105 @@ fn handle_slsa_provenance_v1(sl: SLSAProvenanceV1) -> Result<()> {
     }
 }
 
+/// Handles generation of schemas for In-Toto v1 documents.
+fn generate_intoto_v1(in_toto: GenerateInTotoV1) -> Result<()> {
+    match in_toto.predicate {
+        Some(PredicateOption::SLSAProvenanceV1) => print_schema::<SLSAProvenanceV1Predicate>(),
+        None => print_schema::<InTotoStatementV1>(),
+    }
+}
+
+/// Generates Rust code from a JSON schema file.
+fn code_generate_cmd(cg: CodeGenerate) -> Result<()> {
+    match cg.codegen {
+        CodeGenerateSubCommand::JsonSchema(json_schema) => {
+            let schema_str = std::fs::read_to_string(&json_schema.file)?;
+            generate_rust_code(schema_str)
+        }
+    }
+}
+
+/// Generates Rust code from a JSON schema.
+fn generate_rust_code(schema_str: String) -> Result<()> {
+    let schema = serde_json::from_str::<schemars::schema::RootSchema>(&schema_str)?;
+    let mut type_space = TypeSpace::new(TypeSpaceSettings::default().with_struct_builder(true));
+    type_space.add_root_schema(schema)?;
+
+    let contents = format!(
+        "{}\n{}",
+        "use serde::{Deserialize, Serialize};",
+        prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream())?)
+    );
+    println!("{}", contents);
+
+    Ok(())
+}
+
+/// Prints a JSON schema for the given type T.
+fn print_schema<T: serde::Serialize + schemars::JsonSchema>() -> Result<()> {
+    let schema = schemars::schema_for!(T);
+    println!("{}", serde_json::to_string_pretty(&schema)?);
+    Ok(())
+}
+
+/// Handles validation of documents to JSON schemas.
+///
+/// Prints the document if valid, otherwise prints an error message
+fn schema_validate_cmd<T: DeserializeOwned>(sv: SchemaValidate) -> Result<()> {
+    let file_str = std::fs::read_to_string(&sv.file)?;
+    let schema_str = std::fs::read_to_string(&sv.schema)?;
+    let schema = serde_json::from_str::<serde_json::Value>(&schema_str)?;
+    let validator = validate::JSONSchemaValidator::<Value>::new(&schema);
+    let document = serde_json::from_str::<serde_json::Value>(&file_str)?;
+    let result: std::result::Result<Value, anyhow::Error> = validator.validate(&document);
+
+    match result {
+        Ok(_) => {
+            println!("Valid document based on JSON schema");
+            match serde_json::from_value::<T>(document) {
+                Ok(_) => {
+                    println!("Document: {}", &file_str);
+                    Ok(())
+                }
+                Err(err) => {
+                    eprintln!("Error validating document against Serde structs: {}", err);
+                    Err(err.into())
+                }
+            }
+        }
+        Err(err) => {
+            eprintln!("Error validating document against JSON schema: {}", err);
+            Err(err.into())
+        }
+    }
+}
+
 fn main() {
     let opts: Spector = Spector::parse();
     match opts.command {
         Command::Validate(validate) => {
-            if let Err(_) = validate_cmd(validate) {
+            if let Err(e) = validate_cmd(validate) {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        }
+        Command::SchemaGenerate(generate) => {
+            if let Err(e) = generate_cmd(generate) {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        }
+        Command::SchemaValidate(sv) => {
+            // TODO(mlieberman85): Update this once we support validating against the JSON schema AND the
+            // Serde structs at the same time.
+            if let Err(e) = schema_validate_cmd::<Value>(sv) {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        }
+        Command::CodeGenerate(cg) => {
+            if let Err(e) = code_generate_cmd(cg) {
+                eprintln!("Error: {}", e);
                 process::exit(1);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod models;
+pub mod validate;

--- a/src/models/intoto/mod.rs
+++ b/src/models/intoto/mod.rs
@@ -1,3 +1,6 @@
 pub mod predicate;
 pub mod provenance;
 pub mod statement;
+
+// NOTE(mlieberman85): Many of the models include additional schemars attributes, e.g. "with".
+// See: https://github.com/GREsau/schemars/issues/89 for more info.

--- a/src/models/intoto/predicate.rs
+++ b/src/models/intoto/predicate.rs
@@ -5,6 +5,7 @@
 //! and generic `Other` variants.
 
 use super::provenance::SLSAProvenanceV1Predicate;
+use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 
@@ -12,7 +13,11 @@ use serde_json::Value;
 ///
 /// Known predicate types have their own variants, while unknown types are represented
 /// by the `Other` variant, which stores the raw JSON value.
-#[derive(Debug, Serialize, PartialEq)]
+///
+/// TODO(mlieberman85): Support (de)serializing the predicates based on the
+/// predicateType URL in the statement.
+#[derive(Debug, Serialize, PartialEq, JsonSchema)]
+#[serde(untagged)]
 pub enum Predicate {
     SLSAProvenanceV1(SLSAProvenanceV1Predicate),
     Other(Value),

--- a/src/models/intoto/statement.rs
+++ b/src/models/intoto/statement.rs
@@ -4,28 +4,35 @@
 //! subjects, algorithms, and digest sets. It also includes custom (de)serialization
 //! code for handling In-Toto v1 statements.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use url::Url;
 use std::collections::HashMap;
+use url::Url;
 
-use crate::models::{intoto::predicate::{deserialize_predicate, Predicate}, helpers::url_serde};
+use crate::models::{
+    helpers::url_serde,
+    intoto::predicate::{deserialize_predicate, Predicate},
+};
 
 /// Represents an In-Toto v1 statement.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, JsonSchema)]
 pub struct InTotoStatementV1 {
     #[serde(rename = "_type", with = "url_serde")]
+    #[schemars(with = "Url")]
     pub _type: Url,
     pub subject: Vec<Subject>,
     #[serde(rename = "predicateType", with = "url_serde")]
+    #[schemars(with = "Url")]
     pub predicate_type: Url,
     pub predicate: Predicate,
 }
 
 /// Enum for the supported hashing algorithms.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Algorithm {
+    // TODO(mlieberman85): Add validation for the length/encoding of the digest string.
     Sha224,
     Sha256,
     Sha384,
@@ -48,11 +55,11 @@ pub enum Algorithm {
 }
 
 /// Represents a set of digests, mapping algorithms to their respective digest strings.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct DigestSet(HashMap<Algorithm, String>);
 
 /// Represents a subject in an In-Toto v1 statement.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct Subject {
     pub name: String,
     pub digest: DigestSet,
@@ -112,7 +119,10 @@ mod tests {
 
         let statement: InTotoStatementV1 = serde_json::from_str(json_data).unwrap();
         assert_eq!(statement._type.as_str(), "https://in-toto.io/Statement/v1");
-        assert_eq!(statement.predicate_type.as_str(), "https://random.type/predicate/v1");
+        assert_eq!(
+            statement.predicate_type.as_str(),
+            "https://random.type/predicate/v1"
+        );
         assert_eq!(statement.subject[0].name, "example");
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,2 +1,7 @@
 mod helpers;
 pub mod intoto;
+pub mod sbom;
+
+// NOTE: Throughout the models, several of the Options have a serde attribute of `skip_serializing_if = "Option::is_none"`.
+// This is required to ensure that the JSON schema output is correct. Without this, it will default the value to "null" and
+// other things like Rust codegen from the schema will not work correctly.

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -1,0 +1,131 @@
+//! Validator trait and implementations for validating JSON values.
+//!
+//! This currently supports JSONSchema validation.
+//! This additional validation helps ensure all errors during validation are returned to the user.
+//! Serde will short-circuit on the first error it encounters. Thi means that if there are multiple
+//! the user will have to correct an error in their doc and repeat until Spector reports no more errors.
+
+use anyhow::{anyhow, Result};
+use jsonschema::JSONSchema;
+use serde::de::DeserializeOwned;
+use serde_json::{from_value, Value};
+
+/// A trait for implementing validation logic on JSON values.
+pub trait Validator {
+    type Output;
+
+    /// Validates the given JSON value and assuming no errors returns the deserialized output.
+    fn validate(&self, value: &Value) -> Result<Self::Output>;
+}
+
+/// A JSON Schema-based validator for JSON values.
+///
+/// The `JSONSchemaValidator` struct uses a JSON Schema to validate a JSON value and
+/// then deserializes if it is valid into the specified output type.
+pub struct JSONSchemaValidator<T: DeserializeOwned> {
+    schema: Value,
+
+    // TODO(mlieberman85): this using phantomdata seems like an easy way to tell it return a deserialized values
+    // but I should probably look into if I can make this simpler.
+    _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: DeserializeOwned> JSONSchemaValidator<T> {
+    /// Creates a new JSONSchemaValidator with the given JSON Schema.
+    pub fn new(schema: &Value) -> Self {
+        Self {
+            schema: schema.clone(),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: DeserializeOwned> Validator for JSONSchemaValidator<T> {
+    type Output = T;
+
+    fn validate(&self, value: &Value) -> Result<Self::Output> {
+        let schema = JSONSchema::compile(&self.schema)
+            .map_err(|e| anyhow!("Failed to compile schema: {}", e))?;
+
+        let validate = schema.validate(value);
+
+        match validate {
+            Ok(_) => {
+                let deserialized_value = from_value(value.clone())
+                    .map_err(|e| anyhow!("Failed to deserialize value: {}", e))?;
+                Ok(deserialized_value)
+            }
+            Err(e) => {
+                let error_messages = e
+                    .map(|e| {
+                        format!(
+                            "{}\npath: {}",
+                            serde_json::to_string_pretty(&e.instance).unwrap_or(e.to_string()),
+                            e.instance_path
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(anyhow!("Failed to validate JSON value: {}", error_messages))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    struct Person {
+        name: String,
+        age: u32,
+    }
+
+    fn person_schema() -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "age": { "type": "integer" }
+            },
+            "required": ["name", "age"]
+        })
+    }
+
+    #[test]
+    fn test_valid_person() {
+        let schema = person_schema();
+        let validator = JSONSchemaValidator::<Person>::new(&schema);
+
+        let valid_value = json!({
+            "name": "John Doe",
+            "age": 30
+        });
+
+        let person = validator.validate(&valid_value).unwrap();
+        assert_eq!(
+            person,
+            Person {
+                name: "John Doe".into(),
+                age: 30
+            }
+        );
+    }
+
+    #[test]
+    fn test_invalid_person() {
+        let schema = person_schema();
+        let validator = JSONSchemaValidator::<Person>::new(&schema);
+
+        let invalid_value = json!({
+            "name": 123,
+            "age": "thirty"
+        });
+
+        assert!(validator.validate(&invalid_value).is_err());
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,7 +17,6 @@ fn test_valid_slsa_provenance_v1_document() {
     cmd.args(&[
         "validate",
         "in-toto-v1",
-        "slsa-provenance-v1",
         "--file",
         fixture.to_str().unwrap(),
     ])
@@ -36,7 +35,6 @@ fn test_invalid_slsa_provenance_v1_document() {
     cmd.args(&[
         "validate",
         "in-toto-v1",
-        "slsa-provenance-v1",
         "--file",
         fixture.to_str().unwrap(),
     ])
@@ -55,6 +53,7 @@ fn test_invalid_predicate_slsa_provenance_v1_document() {
     cmd.args(&[
         "validate",
         "in-toto-v1",
+        "--predicate",
         "slsa-provenance-v1",
         "--file",
         fixture.to_str().unwrap(),
@@ -64,4 +63,37 @@ fn test_invalid_predicate_slsa_provenance_v1_document() {
     .stderr(predicate::str::contains(
         "Unexpected predicateType: \"https://slsa.dev/provenance/v12\"",
     ));
+}
+
+#[test]
+fn test_generate_in_toto_v1_schema() {
+    let mut cmd = Command::cargo_bin("spector").unwrap();
+    let fixture = std::fs::read_to_string(fixture_path("in_toto_v1_schema.json")).unwrap();
+
+    cmd.args(&["schema-generate", "in-toto-v1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(fixture));
+}
+
+#[test]
+fn test_generate_slsa_provenance_v1_schema() {
+    let mut cmd = Command::cargo_bin("spector").unwrap();
+    let fixture = std::fs::read_to_string(fixture_path("slsa_provenance_v1_schema.json")).unwrap();
+
+    cmd.args(&["schema-generate", "in-toto-v1", "--predicate", "slsa-provenance-v1"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(fixture));
+}
+
+#[test]
+fn test_generate_rust_code() {
+    let mut cmd = Command::cargo_bin("spector").unwrap();
+    let fixture = std::fs::read_to_string(fixture_path("in_toto_v1.rs")).unwrap();
+
+    cmd.args(&["code-generate", "json-schema", "--file", "tests/fixtures/in_toto_v1_schema.json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(fixture));
 }

--- a/tests/fixtures/in_toto_v1.rs
+++ b/tests/fixtures/in_toto_v1.rs
@@ -1,0 +1,957 @@
+use serde::{Deserialize, Serialize};
+///A structure representing the build definition of the SLSA Provenance v1 Predicate.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BuildDefinition {
+    #[serde(rename = "buildType")]
+    pub build_type: String,
+    #[serde(rename = "externalParameters")]
+    pub external_parameters: serde_json::Value,
+    #[serde(rename = "internalParameters")]
+    pub internal_parameters: serde_json::Value,
+    #[serde(rename = "resolvedDependencies")]
+    pub resolved_dependencies: Vec<ResourceDescriptor>,
+}
+impl From<&BuildDefinition> for BuildDefinition {
+    fn from(value: &BuildDefinition) -> Self {
+        value.clone()
+    }
+}
+impl BuildDefinition {
+    pub fn builder() -> builder::BuildDefinition {
+        builder::BuildDefinition::default()
+    }
+}
+///A structure representing the builder information of the SLSA Provenance v1 Predicate.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Builder {
+    #[serde(
+        rename = "builderDependencies",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub builder_dependencies: Option<Vec<ResourceDescriptor>>,
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+impl From<&Builder> for Builder {
+    fn from(value: &Builder) -> Self {
+        value.clone()
+    }
+}
+impl Builder {
+    pub fn builder() -> builder::Builder {
+        builder::Builder::default()
+    }
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DigestSet(pub std::collections::HashMap<String, String>);
+impl std::ops::Deref for DigestSet {
+    type Target = std::collections::HashMap<String, String>;
+    fn deref(&self) -> &std::collections::HashMap<String, String> {
+        &self.0
+    }
+}
+impl From<DigestSet> for std::collections::HashMap<String, String> {
+    fn from(value: DigestSet) -> Self {
+        value.0
+    }
+}
+impl From<&DigestSet> for DigestSet {
+    fn from(value: &DigestSet) -> Self {
+        value.clone()
+    }
+}
+impl From<std::collections::HashMap<String, String>> for DigestSet {
+    fn from(value: std::collections::HashMap<String, String>) -> Self {
+        Self(value)
+    }
+}
+///Represents an In-Toto v1 statement.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct InTotoStatementV1 {
+    pub predicate: Predicate,
+    #[serde(rename = "predicateType")]
+    pub predicate_type: String,
+    pub subject: Vec<Subject>,
+    #[serde(rename = "_type")]
+    pub type_: String,
+}
+impl From<&InTotoStatementV1> for InTotoStatementV1 {
+    fn from(value: &InTotoStatementV1) -> Self {
+        value.clone()
+    }
+}
+impl InTotoStatementV1 {
+    pub fn builder() -> builder::InTotoStatementV1 {
+        builder::InTotoStatementV1::default()
+    }
+}
+///A structure representing the metadata of the SLSA Provenance v1 Predicate.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Metadata {
+    #[serde(rename = "finishedOn", default, skip_serializing_if = "Option::is_none")]
+    pub finished_on: Option<chrono::DateTime<chrono::offset::Utc>>,
+    #[serde(rename = "invocationId")]
+    pub invocation_id: String,
+    #[serde(rename = "startedOn")]
+    pub started_on: chrono::DateTime<chrono::offset::Utc>,
+}
+impl From<&Metadata> for Metadata {
+    fn from(value: &Metadata) -> Self {
+        value.clone()
+    }
+}
+impl Metadata {
+    pub fn builder() -> builder::Metadata {
+        builder::Metadata::default()
+    }
+}
+/**An enum representing different predicate types.
+
+Known predicate types have their own variants, while unknown types are represented by the `Other` variant, which stores the raw JSON value.
+
+TODO(mlieberman85): Support (de)serializing the predicates based on the predicateType URL in the statement.*/
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Predicate {
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_0: Option<SlsaProvenanceV1Predicate>,
+    #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
+    pub subtype_1: Option<serde_json::Value>,
+}
+impl From<&Predicate> for Predicate {
+    fn from(value: &Predicate) -> Self {
+        value.clone()
+    }
+}
+impl Predicate {
+    pub fn builder() -> builder::Predicate {
+        builder::Predicate::default()
+    }
+}
+///A structure representing a resource descriptor in the SLSA Provenance v1 Predicate.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ResourceDescriptor {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub digest: Option<std::collections::HashMap<String, String>>,
+    #[serde(
+        rename = "downloadLocation",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub download_location: Option<String>,
+    #[serde(rename = "mediaType", default, skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub uri: String,
+}
+impl From<&ResourceDescriptor> for ResourceDescriptor {
+    fn from(value: &ResourceDescriptor) -> Self {
+        value.clone()
+    }
+}
+impl ResourceDescriptor {
+    pub fn builder() -> builder::ResourceDescriptor {
+        builder::ResourceDescriptor::default()
+    }
+}
+///A structure representing the run details of the SLSA Provenance v1 Predicate.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct RunDetails {
+    pub builder: Builder,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub byproducts: Option<Vec<ResourceDescriptor>>,
+    pub metadata: Metadata,
+}
+impl From<&RunDetails> for RunDetails {
+    fn from(value: &RunDetails) -> Self {
+        value.clone()
+    }
+}
+impl RunDetails {
+    pub fn builder() -> builder::RunDetails {
+        builder::RunDetails::default()
+    }
+}
+///A structure representing the SLSA Provenance v1 Predicate.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SlsaProvenanceV1Predicate {
+    #[serde(rename = "buildDefinition")]
+    pub build_definition: BuildDefinition,
+    #[serde(rename = "runDetails")]
+    pub run_details: RunDetails,
+}
+impl From<&SlsaProvenanceV1Predicate> for SlsaProvenanceV1Predicate {
+    fn from(value: &SlsaProvenanceV1Predicate) -> Self {
+        value.clone()
+    }
+}
+impl SlsaProvenanceV1Predicate {
+    pub fn builder() -> builder::SlsaProvenanceV1Predicate {
+        builder::SlsaProvenanceV1Predicate::default()
+    }
+}
+///Represents a subject in an In-Toto v1 statement.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Subject {
+    pub digest: DigestSet,
+    pub name: String,
+}
+impl From<&Subject> for Subject {
+    fn from(value: &Subject) -> Self {
+        value.clone()
+    }
+}
+impl Subject {
+    pub fn builder() -> builder::Subject {
+        builder::Subject::default()
+    }
+}
+pub mod builder {
+    #[derive(Clone, Debug)]
+    pub struct BuildDefinition {
+        build_type: Result<String, String>,
+        external_parameters: Result<serde_json::Value, String>,
+        internal_parameters: Result<serde_json::Value, String>,
+        resolved_dependencies: Result<Vec<super::ResourceDescriptor>, String>,
+    }
+    impl Default for BuildDefinition {
+        fn default() -> Self {
+            Self {
+                build_type: Err("no value supplied for build_type".to_string()),
+                external_parameters: Err(
+                    "no value supplied for external_parameters".to_string(),
+                ),
+                internal_parameters: Err(
+                    "no value supplied for internal_parameters".to_string(),
+                ),
+                resolved_dependencies: Err(
+                    "no value supplied for resolved_dependencies".to_string(),
+                ),
+            }
+        }
+    }
+    impl BuildDefinition {
+        pub fn build_type<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<String>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .build_type = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for build_type: {}", e)
+                });
+            self
+        }
+        pub fn external_parameters<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<serde_json::Value>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .external_parameters = value
+                .try_into()
+                .map_err(|e| {
+                    format!(
+                        "error converting supplied value for external_parameters: {}", e
+                    )
+                });
+            self
+        }
+        pub fn internal_parameters<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<serde_json::Value>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .internal_parameters = value
+                .try_into()
+                .map_err(|e| {
+                    format!(
+                        "error converting supplied value for internal_parameters: {}", e
+                    )
+                });
+            self
+        }
+        pub fn resolved_dependencies<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Vec<super::ResourceDescriptor>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .resolved_dependencies = value
+                .try_into()
+                .map_err(|e| {
+                    format!(
+                        "error converting supplied value for resolved_dependencies: {}",
+                        e
+                    )
+                });
+            self
+        }
+    }
+    impl std::convert::TryFrom<BuildDefinition> for super::BuildDefinition {
+        type Error = String;
+        fn try_from(value: BuildDefinition) -> Result<Self, String> {
+            Ok(Self {
+                build_type: value.build_type?,
+                external_parameters: value.external_parameters?,
+                internal_parameters: value.internal_parameters?,
+                resolved_dependencies: value.resolved_dependencies?,
+            })
+        }
+    }
+    impl From<super::BuildDefinition> for BuildDefinition {
+        fn from(value: super::BuildDefinition) -> Self {
+            Self {
+                build_type: Ok(value.build_type),
+                external_parameters: Ok(value.external_parameters),
+                internal_parameters: Ok(value.internal_parameters),
+                resolved_dependencies: Ok(value.resolved_dependencies),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct Builder {
+        builder_dependencies: Result<Option<Vec<super::ResourceDescriptor>>, String>,
+        id: Result<String, String>,
+        version: Result<Option<String>, String>,
+    }
+    impl Default for Builder {
+        fn default() -> Self {
+            Self {
+                builder_dependencies: Ok(Default::default()),
+                id: Err("no value supplied for id".to_string()),
+                version: Ok(Default::default()),
+            }
+        }
+    }
+    impl Builder {
+        pub fn builder_dependencies<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<Vec<super::ResourceDescriptor>>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .builder_dependencies = value
+                .try_into()
+                .map_err(|e| {
+                    format!(
+                        "error converting supplied value for builder_dependencies: {}", e
+                    )
+                });
+            self
+        }
+        pub fn id<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<String>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .id = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for id: {}", e));
+            self
+        }
+        pub fn version<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<String>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .version = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for version: {}", e)
+                });
+            self
+        }
+    }
+    impl std::convert::TryFrom<Builder> for super::Builder {
+        type Error = String;
+        fn try_from(value: Builder) -> Result<Self, String> {
+            Ok(Self {
+                builder_dependencies: value.builder_dependencies?,
+                id: value.id?,
+                version: value.version?,
+            })
+        }
+    }
+    impl From<super::Builder> for Builder {
+        fn from(value: super::Builder) -> Self {
+            Self {
+                builder_dependencies: Ok(value.builder_dependencies),
+                id: Ok(value.id),
+                version: Ok(value.version),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct InTotoStatementV1 {
+        predicate: Result<super::Predicate, String>,
+        predicate_type: Result<String, String>,
+        subject: Result<Vec<super::Subject>, String>,
+        type_: Result<String, String>,
+    }
+    impl Default for InTotoStatementV1 {
+        fn default() -> Self {
+            Self {
+                predicate: Err("no value supplied for predicate".to_string()),
+                predicate_type: Err("no value supplied for predicate_type".to_string()),
+                subject: Err("no value supplied for subject".to_string()),
+                type_: Err("no value supplied for type_".to_string()),
+            }
+        }
+    }
+    impl InTotoStatementV1 {
+        pub fn predicate<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<super::Predicate>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .predicate = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for predicate: {}", e)
+                });
+            self
+        }
+        pub fn predicate_type<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<String>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .predicate_type = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for predicate_type: {}", e)
+                });
+            self
+        }
+        pub fn subject<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Vec<super::Subject>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .subject = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for subject: {}", e)
+                });
+            self
+        }
+        pub fn type_<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<String>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .type_ = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for type_: {}", e)
+                });
+            self
+        }
+    }
+    impl std::convert::TryFrom<InTotoStatementV1> for super::InTotoStatementV1 {
+        type Error = String;
+        fn try_from(value: InTotoStatementV1) -> Result<Self, String> {
+            Ok(Self {
+                predicate: value.predicate?,
+                predicate_type: value.predicate_type?,
+                subject: value.subject?,
+                type_: value.type_?,
+            })
+        }
+    }
+    impl From<super::InTotoStatementV1> for InTotoStatementV1 {
+        fn from(value: super::InTotoStatementV1) -> Self {
+            Self {
+                predicate: Ok(value.predicate),
+                predicate_type: Ok(value.predicate_type),
+                subject: Ok(value.subject),
+                type_: Ok(value.type_),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct Metadata {
+        finished_on: Result<Option<chrono::DateTime<chrono::offset::Utc>>, String>,
+        invocation_id: Result<String, String>,
+        started_on: Result<chrono::DateTime<chrono::offset::Utc>, String>,
+    }
+    impl Default for Metadata {
+        fn default() -> Self {
+            Self {
+                finished_on: Ok(Default::default()),
+                invocation_id: Err("no value supplied for invocation_id".to_string()),
+                started_on: Err("no value supplied for started_on".to_string()),
+            }
+        }
+    }
+    impl Metadata {
+        pub fn finished_on<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<chrono::DateTime<chrono::offset::Utc>>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .finished_on = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for finished_on: {}", e)
+                });
+            self
+        }
+        pub fn invocation_id<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<String>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .invocation_id = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for invocation_id: {}", e)
+                });
+            self
+        }
+        pub fn started_on<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<chrono::DateTime<chrono::offset::Utc>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .started_on = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for started_on: {}", e)
+                });
+            self
+        }
+    }
+    impl std::convert::TryFrom<Metadata> for super::Metadata {
+        type Error = String;
+        fn try_from(value: Metadata) -> Result<Self, String> {
+            Ok(Self {
+                finished_on: value.finished_on?,
+                invocation_id: value.invocation_id?,
+                started_on: value.started_on?,
+            })
+        }
+    }
+    impl From<super::Metadata> for Metadata {
+        fn from(value: super::Metadata) -> Self {
+            Self {
+                finished_on: Ok(value.finished_on),
+                invocation_id: Ok(value.invocation_id),
+                started_on: Ok(value.started_on),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct Predicate {
+        subtype_0: Result<Option<super::SlsaProvenanceV1Predicate>, String>,
+        subtype_1: Result<Option<serde_json::Value>, String>,
+    }
+    impl Default for Predicate {
+        fn default() -> Self {
+            Self {
+                subtype_0: Ok(Default::default()),
+                subtype_1: Ok(Default::default()),
+            }
+        }
+    }
+    impl Predicate {
+        pub fn subtype_0<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<super::SlsaProvenanceV1Predicate>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .subtype_0 = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for subtype_0: {}", e)
+                });
+            self
+        }
+        pub fn subtype_1<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<serde_json::Value>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .subtype_1 = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for subtype_1: {}", e)
+                });
+            self
+        }
+    }
+    impl std::convert::TryFrom<Predicate> for super::Predicate {
+        type Error = String;
+        fn try_from(value: Predicate) -> Result<Self, String> {
+            Ok(Self {
+                subtype_0: value.subtype_0?,
+                subtype_1: value.subtype_1?,
+            })
+        }
+    }
+    impl From<super::Predicate> for Predicate {
+        fn from(value: super::Predicate) -> Self {
+            Self {
+                subtype_0: Ok(value.subtype_0),
+                subtype_1: Ok(value.subtype_1),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct ResourceDescriptor {
+        annotations: Result<Option<serde_json::Value>, String>,
+        content: Result<Option<String>, String>,
+        digest: Result<Option<std::collections::HashMap<String, String>>, String>,
+        download_location: Result<Option<String>, String>,
+        media_type: Result<Option<String>, String>,
+        name: Result<Option<String>, String>,
+        uri: Result<String, String>,
+    }
+    impl Default for ResourceDescriptor {
+        fn default() -> Self {
+            Self {
+                annotations: Ok(Default::default()),
+                content: Ok(Default::default()),
+                digest: Ok(Default::default()),
+                download_location: Ok(Default::default()),
+                media_type: Ok(Default::default()),
+                name: Ok(Default::default()),
+                uri: Err("no value supplied for uri".to_string()),
+            }
+        }
+    }
+    impl ResourceDescriptor {
+        pub fn annotations<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<serde_json::Value>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .annotations = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for annotations: {}", e)
+                });
+            self
+        }
+        pub fn content<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<String>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .content = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for content: {}", e)
+                });
+            self
+        }
+        pub fn digest<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<std::collections::HashMap<String, String>>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .digest = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for digest: {}", e)
+                });
+            self
+        }
+        pub fn download_location<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<String>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .download_location = value
+                .try_into()
+                .map_err(|e| {
+                    format!(
+                        "error converting supplied value for download_location: {}", e
+                    )
+                });
+            self
+        }
+        pub fn media_type<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<String>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .media_type = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for media_type: {}", e)
+                });
+            self
+        }
+        pub fn name<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<String>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .name = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for name: {}", e));
+            self
+        }
+        pub fn uri<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<String>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .uri = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for uri: {}", e));
+            self
+        }
+    }
+    impl std::convert::TryFrom<ResourceDescriptor> for super::ResourceDescriptor {
+        type Error = String;
+        fn try_from(value: ResourceDescriptor) -> Result<Self, String> {
+            Ok(Self {
+                annotations: value.annotations?,
+                content: value.content?,
+                digest: value.digest?,
+                download_location: value.download_location?,
+                media_type: value.media_type?,
+                name: value.name?,
+                uri: value.uri?,
+            })
+        }
+    }
+    impl From<super::ResourceDescriptor> for ResourceDescriptor {
+        fn from(value: super::ResourceDescriptor) -> Self {
+            Self {
+                annotations: Ok(value.annotations),
+                content: Ok(value.content),
+                digest: Ok(value.digest),
+                download_location: Ok(value.download_location),
+                media_type: Ok(value.media_type),
+                name: Ok(value.name),
+                uri: Ok(value.uri),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct RunDetails {
+        builder: Result<super::Builder, String>,
+        byproducts: Result<Option<Vec<super::ResourceDescriptor>>, String>,
+        metadata: Result<super::Metadata, String>,
+    }
+    impl Default for RunDetails {
+        fn default() -> Self {
+            Self {
+                builder: Err("no value supplied for builder".to_string()),
+                byproducts: Ok(Default::default()),
+                metadata: Err("no value supplied for metadata".to_string()),
+            }
+        }
+    }
+    impl RunDetails {
+        pub fn builder<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<super::Builder>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .builder = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for builder: {}", e)
+                });
+            self
+        }
+        pub fn byproducts<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<Option<Vec<super::ResourceDescriptor>>>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .byproducts = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for byproducts: {}", e)
+                });
+            self
+        }
+        pub fn metadata<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<super::Metadata>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .metadata = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for metadata: {}", e)
+                });
+            self
+        }
+    }
+    impl std::convert::TryFrom<RunDetails> for super::RunDetails {
+        type Error = String;
+        fn try_from(value: RunDetails) -> Result<Self, String> {
+            Ok(Self {
+                builder: value.builder?,
+                byproducts: value.byproducts?,
+                metadata: value.metadata?,
+            })
+        }
+    }
+    impl From<super::RunDetails> for RunDetails {
+        fn from(value: super::RunDetails) -> Self {
+            Self {
+                builder: Ok(value.builder),
+                byproducts: Ok(value.byproducts),
+                metadata: Ok(value.metadata),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct SlsaProvenanceV1Predicate {
+        build_definition: Result<super::BuildDefinition, String>,
+        run_details: Result<super::RunDetails, String>,
+    }
+    impl Default for SlsaProvenanceV1Predicate {
+        fn default() -> Self {
+            Self {
+                build_definition: Err(
+                    "no value supplied for build_definition".to_string(),
+                ),
+                run_details: Err("no value supplied for run_details".to_string()),
+            }
+        }
+    }
+    impl SlsaProvenanceV1Predicate {
+        pub fn build_definition<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<super::BuildDefinition>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .build_definition = value
+                .try_into()
+                .map_err(|e| {
+                    format!(
+                        "error converting supplied value for build_definition: {}", e
+                    )
+                });
+            self
+        }
+        pub fn run_details<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<super::RunDetails>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .run_details = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for run_details: {}", e)
+                });
+            self
+        }
+    }
+    impl std::convert::TryFrom<SlsaProvenanceV1Predicate>
+    for super::SlsaProvenanceV1Predicate {
+        type Error = String;
+        fn try_from(value: SlsaProvenanceV1Predicate) -> Result<Self, String> {
+            Ok(Self {
+                build_definition: value.build_definition?,
+                run_details: value.run_details?,
+            })
+        }
+    }
+    impl From<super::SlsaProvenanceV1Predicate> for SlsaProvenanceV1Predicate {
+        fn from(value: super::SlsaProvenanceV1Predicate) -> Self {
+            Self {
+                build_definition: Ok(value.build_definition),
+                run_details: Ok(value.run_details),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct Subject {
+        digest: Result<super::DigestSet, String>,
+        name: Result<String, String>,
+    }
+    impl Default for Subject {
+        fn default() -> Self {
+            Self {
+                digest: Err("no value supplied for digest".to_string()),
+                name: Err("no value supplied for name".to_string()),
+            }
+        }
+    }
+    impl Subject {
+        pub fn digest<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<super::DigestSet>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .digest = value
+                .try_into()
+                .map_err(|e| {
+                    format!("error converting supplied value for digest: {}", e)
+                });
+            self
+        }
+        pub fn name<T>(mut self, value: T) -> Self
+        where
+            T: std::convert::TryInto<String>,
+            T::Error: std::fmt::Display,
+        {
+            self
+                .name = value
+                .try_into()
+                .map_err(|e| format!("error converting supplied value for name: {}", e));
+            self
+        }
+    }
+    impl std::convert::TryFrom<Subject> for super::Subject {
+        type Error = String;
+        fn try_from(value: Subject) -> Result<Self, String> {
+            Ok(Self {
+                digest: value.digest?,
+                name: value.name?,
+            })
+        }
+    }
+    impl From<super::Subject> for Subject {
+        fn from(value: super::Subject) -> Self {
+            Self {
+                digest: Ok(value.digest),
+                name: Ok(value.name),
+            }
+        }
+    }
+}
+

--- a/tests/fixtures/in_toto_v1_schema.json
+++ b/tests/fixtures/in_toto_v1_schema.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InTotoStatementV1",
+  "description": "Represents an In-Toto v1 statement.",
+  "type": "object",
+  "required": [
+    "_type",
+    "predicate",
+    "predicateType",
+    "subject"
+  ],
+  "properties": {
+    "_type": {
+      "type": "string",
+      "format": "uri"
+    },
+    "predicate": {
+      "$ref": "#/definitions/Predicate"
+    },
+    "predicateType": {
+      "type": "string",
+      "format": "uri"
+    },
+    "subject": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Subject"
+      }
+    }
+  },
+  "definitions": {
+    "BuildDefinition": {
+      "description": "A structure representing the build definition of the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "buildType",
+        "externalParameters",
+        "internalParameters",
+        "resolvedDependencies"
+      ],
+      "properties": {
+        "buildType": {
+          "type": "string",
+          "format": "uri"
+        },
+        "externalParameters": true,
+        "internalParameters": true,
+        "resolvedDependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceDescriptor"
+          }
+        }
+      }
+    },
+    "Builder": {
+      "description": "A structure representing the builder information of the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "builderDependencies": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ResourceDescriptor"
+          }
+        },
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "DigestSet": {
+      "description": "Represents a set of digests, mapping algorithms to their respective digest strings.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "Metadata": {
+      "description": "A structure representing the metadata of the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "invocationId",
+        "startedOn"
+      ],
+      "properties": {
+        "finishedOn": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "invocationId": {
+          "type": "string"
+        },
+        "startedOn": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "Predicate": {
+      "description": "An enum representing different predicate types.\n\nKnown predicate types have their own variants, while unknown types are represented by the `Other` variant, which stores the raw JSON value.\n\nTODO(mlieberman85): Support (de)serializing the predicates based on the predicateType URL in the statement.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SLSAProvenanceV1Predicate"
+        },
+        true
+      ]
+    },
+    "ResourceDescriptor": {
+      "description": "A structure representing a resource descriptor in the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "uri"
+      ],
+      "properties": {
+        "annotations": true,
+        "content": {
+          "type": "string"
+        },
+        "digest": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "downloadLocation": {
+          "type": "string",
+          "format": "uri"
+        },
+        "mediaType": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "RunDetails": {
+      "description": "A structure representing the run details of the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "builder",
+        "metadata"
+      ],
+      "properties": {
+        "builder": {
+          "$ref": "#/definitions/Builder"
+        },
+        "byproducts": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ResourceDescriptor"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata"
+        }
+      }
+    },
+    "SLSAProvenanceV1Predicate": {
+      "description": "A structure representing the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "buildDefinition",
+        "runDetails"
+      ],
+      "properties": {
+        "buildDefinition": {
+          "$ref": "#/definitions/BuildDefinition"
+        },
+        "runDetails": {
+          "$ref": "#/definitions/RunDetails"
+        }
+      }
+    },
+    "Subject": {
+      "description": "Represents a subject in an In-Toto v1 statement.",
+      "type": "object",
+      "required": [
+        "digest",
+        "name"
+      ],
+      "properties": {
+        "digest": {
+          "$ref": "#/definitions/DigestSet"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/slsa_provenance_v1_schema.json
+++ b/tests/fixtures/slsa_provenance_v1_schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SLSAProvenanceV1Predicate",
+  "description": "A structure representing the SLSA Provenance v1 Predicate.",
+  "type": "object",
+  "required": [
+    "buildDefinition",
+    "runDetails"
+  ],
+  "properties": {
+    "buildDefinition": {
+      "$ref": "#/definitions/BuildDefinition"
+    },
+    "runDetails": {
+      "$ref": "#/definitions/RunDetails"
+    }
+  },
+  "definitions": {
+    "BuildDefinition": {
+      "description": "A structure representing the build definition of the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "buildType",
+        "externalParameters",
+        "internalParameters",
+        "resolvedDependencies"
+      ],
+      "properties": {
+        "buildType": {
+          "type": "string",
+          "format": "uri"
+        },
+        "externalParameters": true,
+        "internalParameters": true,
+        "resolvedDependencies": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ResourceDescriptor"
+          }
+        }
+      }
+    },
+    "Builder": {
+      "description": "A structure representing the builder information of the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "builderDependencies": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ResourceDescriptor"
+          }
+        },
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Metadata": {
+      "description": "A structure representing the metadata of the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "invocationId",
+        "startedOn"
+      ],
+      "properties": {
+        "finishedOn": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "invocationId": {
+          "type": "string"
+        },
+        "startedOn": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "ResourceDescriptor": {
+      "description": "A structure representing a resource descriptor in the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "uri"
+      ],
+      "properties": {
+        "annotations": true,
+        "content": {
+          "type": "string"
+        },
+        "digest": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "downloadLocation": {
+          "type": "string",
+          "format": "uri"
+        },
+        "mediaType": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "RunDetails": {
+      "description": "A structure representing the run details of the SLSA Provenance v1 Predicate.",
+      "type": "object",
+      "required": [
+        "builder",
+        "metadata"
+      ],
+      "properties": {
+        "builder": {
+          "$ref": "#/definitions/Builder"
+        },
+        "byproducts": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ResourceDescriptor"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds the ability to generate a json schema from a model.
This also adds the ability to generate rust code from a json
schema. This also allows for the validation of a document to a
json schema.

Signed-off-by: Michael Lieberman <mlieberman85@gmail.com>